### PR TITLE
Add client_id and client_secret to token_params

### DIFF
--- a/lib/omniauth/strategies/monday.rb
+++ b/lib/omniauth/strategies/monday.rb
@@ -21,6 +21,10 @@ module OmniAuth
         end
       end
 
+      def token_params
+        super.merge({client_id: options.client_id, client_secret: options.client_secret})
+      end
+
       uid { me["id"] }
 
       extra do


### PR DESCRIPTION
When using this gem, I received the following error:

```
OAuth2::Error (invalid_request: Missing client_id param
{"error":"invalid_request","error_description":"Missing client_id param"}):
```

I'm not sure if that changed recently, but according to the [monday oauth docs](https://developer.monday.com/apps/docs/oauth?utm_source=Dev+section#request-structure) we need to add the `client_id` and `client_secret` to the as params to the token url.