### PR TITLE
Make me graphql query an option.

### DIFF
--- a/lib/omniauth/strategies/monday.rb
+++ b/lib/omniauth/strategies/monday.rb
@@ -47,10 +47,35 @@ module OmniAuth
         <<~GRAPHQL
           query {
             me {
-            email
-            name
-            id
-          }
+              birthday
+              country_code
+              created_at
+              current_language
+              join_date
+              email
+              enabled
+              id
+              is_admin
+              is_guest
+              is_pending
+              is_verified
+              is_view_only
+              last_activity
+              location
+              mobile_phone
+              name
+              phone
+              photo_original
+              photo_small
+              photo_thumb
+              photo_thumb_small
+              photo_tiny
+              sign_up_product_kind
+              time_zone_identifier
+              title
+              url
+              utc_hours_diff
+            }
           }
         GRAPHQL
       end

--- a/lib/omniauth/strategies/monday.rb
+++ b/lib/omniauth/strategies/monday.rb
@@ -9,6 +9,16 @@ module OmniAuth
         token_url: "https://auth.monday.com/oauth2/token",
       }
 
+      option :default_query, <<~GRAPHQL
+        query {
+          me {
+            email
+            name
+            id
+          }
+        }
+      GRAPHQL
+
       def request_phase
         super
       end
@@ -44,40 +54,7 @@ module OmniAuth
       end
 
       def query
-        <<~GRAPHQL
-          query {
-            me {
-              birthday
-              country_code
-              created_at
-              current_language
-              join_date
-              email
-              enabled
-              id
-              is_admin
-              is_guest
-              is_pending
-              is_verified
-              is_view_only
-              last_activity
-              location
-              mobile_phone
-              name
-              phone
-              photo_original
-              photo_small
-              photo_thumb
-              photo_thumb_small
-              photo_tiny
-              sign_up_product_kind
-              time_zone_identifier
-              title
-              url
-              utc_hours_diff
-            }
-          }
-        GRAPHQL
+        options[:query] || options[:default_query]
       end
     end
   end


### PR DESCRIPTION
Per default it will use this query:

```
query {
  me {
    email
    name
    id
  }
}
```

But you can overwrite the default to query whatever fields you wish:

```
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :monday,
    Rails.application.credentials.monday_api_key,
    Rails.application.credentials.monday_api_secret,
    {
      scope: "me:read workspaces:read workspaces:write boards:read boards:write",
      query: <<~GRAPHQL
        query {
          me {
            account{
              slug
              name
            }
            birthday
            country_code
            created_at
            current_language
            join_date
            email
            enabled
            id
            is_admin
            is_guest
            is_pending
            is_verified
            is_view_only
            last_activity
            location
            mobile_phone
            name
            phone
            photo_original
            photo_small
            photo_thumb
            photo_thumb_small
            photo_tiny
            sign_up_product_kind
            time_zone_identifier
            title
            url
            utc_hours_diff
          }
        }
      GRAPHQL
    }
end
```

Query all fields from https://developer.monday.com/api-reference/reference/me#fields